### PR TITLE
prevents sync from setting unset attrs to undef

### DIFF
--- a/lib/Meerkat/Collection.pm
+++ b/lib/Meerkat/Collection.pm
@@ -342,7 +342,8 @@ sub _sync {
     };
     for my $tgt_attr ( $tgt->meta->get_all_attributes ) {
         my $src_attr = $src->meta->find_attribute_by_name( $tgt_attr->name );
-        $tgt_attr->set_value( $tgt, $src_attr->get_value($src) );
+        $tgt_attr->set_value( $tgt, $src_attr->get_value($src) )
+            if $src_attr->has_value($src);
     }
     return 1;
 }


### PR DESCRIPTION
Currently the sync method loops through all attributes in the target object and sets them with the source value for the corresponding attribute.  This means that even unset attributes in the source will become set, undef attributes in the resulting object.

It is important to maintain the difference between attrs set to undef (null fields in document) and attrs that are unset (non-existent fields in document), and this commit ensures that distinction is made when using "sync".

I believe this should be the desired behavior, although it could certainly break backwards compatibility if people are relying on the old (incorrect) behavior. Thoughts?