### PR TITLE
adds "immortal" to the cursor handles

### DIFF
--- a/lib/Meerkat/Cursor.pm
+++ b/lib/Meerkat/Cursor.pm
@@ -23,7 +23,7 @@ has cursor => (
     required => 1,
     handles  => [
         qw( fields sort limit tailable skip snapshot hint ),
-        qw( explain count reset has_next next info all ),
+        qw( explain count reset has_next next info all immortal),
     ],
 );
 


### PR DESCRIPTION
Doing long lasting queries requires you to use $cursor->immortal(1);  
Adding immortal to the handles for the cursor attribute passes this on to
the MongoDB::Cursor and everything will work.