### PR TITLE
Propogate errors from custom collection packages

### DIFF
--- a/lib/Meerkat.pm
+++ b/lib/Meerkat.pm
@@ -137,7 +137,11 @@ sub collection {
     my $class;
     if ( my $prefix = $self->collection_namespace ) {
         $class = compose_module_name( $prefix, $suffix );
-        try { require_module($class) } catch { $class = "Meerkat::Collection" };
+        try { require_module($class) }
+        catch {
+            die $_ unless m/Can't locate/;
+            $class = "Meerkat::Collection"
+        };
     }
     else {
         $class = "Meerkat::Collection";

--- a/t/custom_collection_errors.t
+++ b/t/custom_collection_errors.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::Roo;
+use Test::FailWarnings;
+use Test::Fatal;
+use Test::Requires qw/MongoDB/;
+
+my $conn = eval { MongoDB::MongoClient->new; };
+plan skip_all => "No MongoDB on localhost"
+  unless eval { $conn->get_database("admin")->run_command( [ ismaster => 1 ] ) };
+
+use lib 't/lib';
+
+with 'TestFixtures';
+
+sub _build_meerkat_options {
+    my ($self) = @_;
+    return {
+        model_namespace      => 'My::Model',
+        collection_namespace => 'Bad::Collection',
+        database_name        => 'test',
+    };
+}
+
+test 'meerkat will propogate custom collection errors' => sub {
+    my $self = shift;
+
+    my $err = exception { $self->meerkat->collection('Doom') };
+    like(
+        $err,
+        qr/This attribute will blow up on construction/,
+        "Caught error from custom collection object"
+    );
+
+    my $coll;
+    $err = exception { $coll = $self->meerkat->collection('Person') };
+    ok( !$err, 'No exception when custom collection package is missing' );
+    isa_ok( $coll, 'Meerkat::Collection' );
+};
+
+run_me;
+done_testing;
+# COPYRIGHT
+# vim: ts=4 sts=4 sw=4 et:

--- a/t/lib/Bad/Collection/Doom.pm
+++ b/t/lib/Bad/Collection/Doom.pm
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+
+package Bad::Collection::Doom;
+
+use Moose 2;
+extends 'Meerkat::Collection';
+
+has bad_attribute => (
+    is      => 'ro',
+    default => sub {
+        die "This attribute will blow up on construction";
+    }
+);
+
+1;


### PR DESCRIPTION
Hello!

I was playing around with Meerkat, and couldn't figure out why my custom collection class was being ignored. It turns out I was doing something dumb with Moose (I had a builder and a default for an attribute, oops). Anyway, this PR will make Meerkat screech errors if a custom collection class exists but is broken.

Cheers!