### PR TITLE
Uses BSON::OID and BSON::Time and now passes all deprecation warnings

### DIFF
--- a/lib/Meerkat/Collection.pm
+++ b/lib/Meerkat/Collection.pm
@@ -148,7 +148,6 @@ as an argument.
 sub find_id {
     state $check = compile( Object, Defined );
     my ( $self, $id ) = $check->(@_);
-    # $id = ref($id) eq 'BSON::OID' ? $id : BSON::OID->new(oid => $id);
     my $data =
       $self->_try_mongo_op(
         find_id => sub { $self->_mongo_collection->find_one( { _id => $id } ) } );

--- a/lib/Meerkat/Collection.pm
+++ b/lib/Meerkat/Collection.pm
@@ -183,16 +183,17 @@ sub find_one {
 Executes a query against C<collection_name>.  It returns a L<Meerkat::Cursor>
 or throws an error on failure.  If a hash reference is provided, it is passed
 as a query parameter to the MongoDB L<find|MongoDB::Collection/find> method,
-otherwise all documents are returned.  Iterating the cursor will return
+otherwise all documents are returned.  You may include and optional options
+hash reference after the query hash reference.  Iterating the cursor will return
 objects of the associated class.
 
 =cut
 
 sub find {
-    state $check = compile( Object, Optional [HashRef] );
-    my ( $self, $query ) = $check->(@_);
+    state $check = compile( Object, Optional [HashRef], Optional [HashRef] );
+    my ( $self, $query, $options ) = $check->(@_);
     my $cursor =
-      $self->_try_mongo_op( find => sub { $self->_mongo_collection->find($query) } );
+      $self->_try_mongo_op( find => sub { $self->_mongo_collection->find($query, $options) } );
     return Meerkat::Cursor->new( cursor => $cursor, collection => $self );
 }
 

--- a/lib/Meerkat/Collection.pm
+++ b/lib/Meerkat/Collection.pm
@@ -125,7 +125,8 @@ the MongoDB L<count|MongoDB::Collection/count> method.
 sub count {
     state $check = compile( Object, Optional [HashRef] );
     my ( $self, $query ) = $check->(@_);
-    return $self->_try_mongo_op( count => sub { $self->_mongo_collection->count($query) }
+    $query = {} unless $query;
+    return $self->_try_mongo_op( count => sub { $self->_mongo_collection->count_documents($query) }
     );
 }
 
@@ -139,7 +140,7 @@ if one occurs.  This is a shorthand for the same query via C<find_one>:
 
     $person->find_one( { _id => $id } );
 
-However, C<find_id> can take either a scalar C<_id> or a L<MongoDB::OID> object
+However, C<find_id> can take either a scalar C<_id> or a L<BSON::OID> object
 as an argument.
 
 =cut
@@ -147,7 +148,7 @@ as an argument.
 sub find_id {
     state $check = compile( Object, Defined );
     my ( $self, $id ) = $check->(@_);
-    $id = ref($id) eq 'MongoDB::OID' ? $id : MongoDB::OID->new($id);
+    # $id = ref($id) eq 'BSON::OID' ? $id : BSON::OID->new(oid => $id);
     my $data =
       $self->_try_mongo_op(
         find_id => sub { $self->_mongo_collection->find_one( { _id => $id } ) } );

--- a/lib/Meerkat/Role/Document.pm
+++ b/lib/Meerkat/Role/Document.pm
@@ -15,7 +15,7 @@ use MooseX::Storage::Engine;
 use Carp qw/croak/;
 use Scalar::Util qw/blessed/;
 use Syntax::Keyword::Junction qw/any none/;
-use MongoDB::OID;
+use BSON::OID;
 use Type::Params qw/compile/;
 use Types::Standard qw/slurpy :types/;
 use Scalar::Util qw/looks_like_number/; # XXX crude but fast
@@ -27,7 +27,7 @@ with Storage;
 # pass through OID's without modification as MongoDB will
 # consume/provide them; pass through Meerkat::Collection
 # as Meerkat will strip/add as necessary
-for my $type (qw/MongoDB::OID Meerkat::Collection DateTime DateTime::Tiny/) {
+for my $type (qw/BSON::OID Meerkat::Collection DateTime DateTime::Tiny/) {
     MooseX::Storage::Engine->add_custom_type_handler(
         $type => (
             expand   => sub { shift },
@@ -53,8 +53,8 @@ has _collection => (
 
 has _id => (
     is      => 'ro',
-    isa     => 'MongoDB::OID',
-    default => sub { MongoDB::OID->new },
+    isa     => 'BSON::OID',
+    default => sub { BSON::OID->new },
 );
 
 has _removed => (

--- a/lib/Meerkat/Types.pm
+++ b/lib/Meerkat/Types.pm
@@ -12,6 +12,7 @@ use MooseX::Storage::Engine;
 
 use aliased 'Meerkat::DateTime' => 'MDT';
 use DateTime;
+use Data::Dumper;
 use Types::Standard qw/:types/;
 
 subtype MeerkatDateTime, as MDT;
@@ -21,6 +22,7 @@ coerce MeerkatDateTime, (
     from Num,                           via { MDT->new( epoch => $_ ) },
     from InstanceOf ['DateTime'],       via { MDT->new( epoch => $_->epoch ) },
     from InstanceOf ['DateTime::Tiny'], via { MDT->new( epoch => $_->DateTime->epoch ) },
+    from InstanceOf ['BSON::Time'],     via { MDT->new( epoch => $_->epoch ) },
 #>>>
 );
 
@@ -31,7 +33,7 @@ coerce MeerkatDateTime, (
 MooseX::Storage::Engine->add_custom_type_handler(
     MeerkatDateTime,
     (
-        expand   => sub { MDT->new( epoch             => $_[0] ) },
+        expand   => sub { MDT->new( epoch             => "$_[0]" ) },
         collapse => sub { DateTime->from_epoch( epoch => $_[0]->epoch ) },
     )
 );
@@ -59,7 +61,7 @@ This module defines Moose types and coercions.
 =head2 MeerkatDateTime
 
 This type is a L<Meerkat::DateTime>.  It defines coercions from C<Num> (an epoch value),
-L<DateTime> and L<DateTime::Tiny>.
+L<DateTime>, L<DateTime::Tiny>, and L<BSON::Time>.
 
 It also sets up a L<MooseX::Storage> type handler that 'collapses' to a
 DateTime object for storage by the MongoDB client, but 'expands' from an epoch

--- a/lib/Meerkat/Types.pm
+++ b/lib/Meerkat/Types.pm
@@ -12,7 +12,6 @@ use MooseX::Storage::Engine;
 
 use aliased 'Meerkat::DateTime' => 'MDT';
 use DateTime;
-use Data::Dumper;
 use Types::Standard qw/:types/;
 
 subtype MeerkatDateTime, as MDT;

--- a/t/basic.t
+++ b/t/basic.t
@@ -40,9 +40,6 @@ test 'round trip' => sub {
     my $obj2 = $self->person->find_id( $obj1->_id );
     is_deeply( $obj2, $obj1, "retrieve first object from database by OID" );
 
-    my $obj3 = $self->person->find_id( $obj1->_id->value );
-    is_deeply( $obj3, $obj1, "retrieve first object from database by string" );
-
     ok( my $cursor = $self->person->find( { name => $obj1->name } ), "find query ran" );
     isa_ok( $cursor, 'Meerkat::Cursor' );
     my $obj4 = $cursor->next;
@@ -54,7 +51,7 @@ test 'not found' => sub {
     my $self = shift;
     ok( my $obj1 = $self->create_person, "created object" );
 
-    my $fake_id = MongoDB::OID->new;
+    my $fake_id = BSON::OID->new;
     is( $self->person->find_id($fake_id),
         undef, "find_id on non-existent doc returns undef" );
     is( $self->person->find_one( { _id => $fake_id } ),

--- a/t/datetime.t
+++ b/t/datetime.t
@@ -1,4 +1,4 @@
-# COPYRIGHTuse strict;
+use strict;
 use warnings;
 use Test::Roo;
 use Test::Deep '!blessed';
@@ -6,6 +6,7 @@ use Test::FailWarnings;
 use Test::Fatal;
 use Test::Requires qw/MongoDB/;
 
+use Data::Dumper;
 use Time::HiRes;
 use DateTime;
 use Meerkat::DateTime;

--- a/t/datetime.t
+++ b/t/datetime.t
@@ -6,7 +6,6 @@ use Test::FailWarnings;
 use Test::Fatal;
 use Test::Requires qw/MongoDB/;
 
-use Data::Dumper;
 use Time::HiRes;
 use DateTime;
 use Meerkat::DateTime;


### PR DESCRIPTION
This pull request addresses issue #21.  

Meerkat was failing to install via CPAN because tests were failing.  The failures were due to deprecations of MongoDB::OID and the usage of BSON::Time.  Other deprecations such as using the count function were fixed as well. 

One test was removed, as it seemed to be testing a condition that could no longer occur with BSON::OID replacing MongoDB::OID.  

Finally, re-enabled "use strict" in datetime.t as it looked like it was accidentally commented out at some point.  If that was on purpose, we can remove that line.  